### PR TITLE
Add package predictor example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.json

--- a/package_predictor/README.md
+++ b/package_predictor/README.md
@@ -4,7 +4,9 @@ This directory contains a simple example of training a two-layer neural network
 from a small dataset of product names **and descriptions** to predict package
 size and type. The network is implemented from scratch without external machine
 learning libraries. The CSV file only provides names and descriptions; the
-training script assigns synthetic size/type labels for demonstration.
+training script now generates deterministic synthetic size/type labels from each
+product name using hashing so it can work with any dataset lacking these
+fields.
 
 ## Files
 

--- a/package_predictor/README.md
+++ b/package_predictor/README.md
@@ -1,14 +1,16 @@
 # Package Predictor
 
 This directory contains a simple example of training a neural-network-like model
-from a small dataset of product names to predict package size and type. The model
-is implemented from scratch without external machine learning libraries.
+from a small dataset of product names **and descriptions** to predict package
+size and type. The model is implemented from scratch without external machine
+learning libraries.
 
 ## Files
 
 - `model.py` – minimal implementation of the classifier and persistence
 - `train.py` – trains the model using `data.csv`
-- `predict.py` – loads the saved model and predicts for a given product name
+- `predict.py` – loads the saved model and predicts for a given product name and
+  description
 - `data.csv` – example training data
 
 ## Usage
@@ -19,10 +21,10 @@ Train the model (this creates `model.json`):
 python train.py
 ```
 
-Run a prediction:
+Run a prediction (both name and description must be provided):
 
 ```bash
-python predict.py "cola"
+python predict.py "cola" "sweet carbonated beverage"
 ```
 
 The script outputs the predicted package size and type along with their

--- a/package_predictor/README.md
+++ b/package_predictor/README.md
@@ -1,8 +1,8 @@
 # Package Predictor
 
-This directory contains a simple example of training a neural-network-like model
+This directory contains a simple example of training a two-layer neural network
 from a small dataset of product names **and descriptions** to predict package
-size and type. The model is implemented from scratch without external machine
+size and type. The network is implemented from scratch without external machine
 learning libraries.
 
 ## Files

--- a/package_predictor/README.md
+++ b/package_predictor/README.md
@@ -3,7 +3,8 @@
 This directory contains a simple example of training a two-layer neural network
 from a small dataset of product names **and descriptions** to predict package
 size and type. The network is implemented from scratch without external machine
-learning libraries.
+learning libraries. The CSV file only provides names and descriptions; the
+training script assigns synthetic size/type labels for demonstration.
 
 ## Files
 
@@ -11,7 +12,7 @@ learning libraries.
 - `train.py` – trains the model using `data.csv`
 - `predict.py` – loads the saved model and predicts for a given product name and
   description
-- `data.csv` – example training data
+- `data.csv` – example training data containing only names and descriptions
 
 ## Usage
 

--- a/package_predictor/README.md
+++ b/package_predictor/README.md
@@ -1,14 +1,15 @@
 # Package Predictor
 
 This directory contains a simple example of training a neural-network-like model
-from a small list of product names to predict package size and type. The model
+from a small dataset of product names to predict package size and type. The model
 is implemented from scratch without external machine learning libraries.
 
 ## Files
 
 - `model.py` – minimal implementation of the classifier and persistence
-- `train.py` – generates a small dataset and trains the model
+- `train.py` – trains the model using `data.csv`
 - `predict.py` – loads the saved model and predicts for a given product name
+- `data.csv` – example training data
 
 ## Usage
 

--- a/package_predictor/README.md
+++ b/package_predictor/README.md
@@ -1,0 +1,28 @@
+# Package Predictor
+
+This directory contains a simple example of training a neural-network-like model
+from a small list of product names to predict package size and type. The model
+is implemented from scratch without external machine learning libraries.
+
+## Files
+
+- `model.py` – minimal implementation of the classifier and persistence
+- `train.py` – generates a small dataset and trains the model
+- `predict.py` – loads the saved model and predicts for a given product name
+
+## Usage
+
+Train the model (this creates `model.json`):
+
+```bash
+python train.py
+```
+
+Run a prediction:
+
+```bash
+python predict.py "cola"
+```
+
+The script outputs the predicted package size and type along with their
+confidence values.

--- a/package_predictor/data.csv
+++ b/package_predictor/data.csv
@@ -1,0 +1,11 @@
+name,size,type
+cola,500ml,bottle
+orange juice,1l,bottle
+mineral water,500ml,bottle
+potato chips,200g,bag
+chocolate cookies,300g,bag
+rice 5kg,5kg,bag
+smartphone,small,box
+laptop computer,medium,box
+television,large,box
+breakfast cereal,500g,box

--- a/package_predictor/data.csv
+++ b/package_predictor/data.csv
@@ -1,11 +1,11 @@
-name,size,type
-cola,500ml,bottle
-orange juice,1l,bottle
-mineral water,500ml,bottle
-potato chips,200g,bag
-chocolate cookies,300g,bag
-rice 5kg,5kg,bag
-smartphone,small,box
-laptop computer,medium,box
-television,large,box
-breakfast cereal,500g,box
+name,description,size,type
+cola,sweet carbonated beverage,500ml,bottle
+orange juice,citrus fruit drink,1l,bottle
+mineral water,pure spring water,500ml,bottle
+potato chips,crispy salted snack,200g,bag
+chocolate cookies,sweet baked biscuit,300g,bag
+rice 5kg,staple grain 5 kilogram package,5kg,bag
+smartphone,handheld electronic device,small,box
+laptop computer,portable personal computer,medium,box
+television,large flat screen tv,large,box
+breakfast cereal,morning meal grains,500g,box

--- a/package_predictor/data.csv
+++ b/package_predictor/data.csv
@@ -1,11 +1,11 @@
-name,description,size,type
-cola,sweet carbonated beverage,500ml,bottle
-orange juice,citrus fruit drink,1l,bottle
-mineral water,pure spring water,500ml,bottle
-potato chips,crispy salted snack,200g,bag
-chocolate cookies,sweet baked biscuit,300g,bag
-rice 5kg,staple grain 5 kilogram package,5kg,bag
-smartphone,handheld electronic device,small,box
-laptop computer,portable personal computer,medium,box
-television,large flat screen tv,large,box
-breakfast cereal,morning meal grains,500g,box
+name,description
+cola,sweet carbonated beverage
+orange juice,citrus fruit drink
+mineral water,pure spring water
+potato chips,crispy salted snack
+chocolate cookies,sweet baked biscuit
+rice 5kg,staple grain 5 kilogram package
+smartphone,handheld electronic device
+laptop computer,portable personal computer
+television,large flat screen tv
+breakfast cereal,morning meal grains

--- a/package_predictor/model.py
+++ b/package_predictor/model.py
@@ -39,34 +39,68 @@ def softmax(logits: List[float]) -> List[float]:
     return [e / s for e in exps]
 
 
-class SimpleClassifier:
-    def __init__(self, input_dim: int, num_classes: int, lr: float = 0.1):
+class SimpleNN:
+    """Minimal two-layer neural network with tanh activation."""
+
+    def __init__(
+        self, input_dim: int, hidden_dim: int, num_classes: int, lr: float = 0.1
+    ):
         self.lr = lr
         self.num_classes = num_classes
-        self.weights = [
+        self.hidden_dim = hidden_dim
+        self.hidden_weights = [
             [random.uniform(-0.01, 0.01) for _ in range(input_dim)]
+            for _ in range(hidden_dim)
+        ]
+        self.hidden_biases = [0.0 for _ in range(hidden_dim)]
+        self.out_weights = [
+            [random.uniform(-0.01, 0.01) for _ in range(hidden_dim)]
             for _ in range(num_classes)
         ]
-        self.biases = [0.0 for _ in range(num_classes)]
+        self.out_biases = [0.0 for _ in range(num_classes)]
 
-    def predict_proba(self, vec: List[float]) -> List[float]:
+    def _forward(self, vec: List[float]) -> Tuple[List[float], List[float]]:
+        hidden = []
+        for j in range(self.hidden_dim):
+            h = self.hidden_biases[j]
+            for i, val in enumerate(vec):
+                h += self.hidden_weights[j][i] * val
+            hidden.append(math.tanh(h))
+
         logits = []
         for c in range(self.num_classes):
-            logit = self.biases[c]
-            for i, val in enumerate(vec):
-                logit += self.weights[c][i] * val
+            logit = self.out_biases[c]
+            for j, h in enumerate(hidden):
+                logit += self.out_weights[c][j] * h
             logits.append(logit)
-        return softmax(logits)
+        return hidden, softmax(logits)
+
+    def predict_proba(self, vec: List[float]) -> List[float]:
+        _, probs = self._forward(vec)
+        return probs
 
     def train(self, X: List[List[float]], y: List[int], epochs: int = 50):
         for _ in range(epochs):
             for vec, label in zip(X, y):
-                probs = self.predict_proba(vec)
+                hidden, probs = self._forward(vec)
+                # Gradient for output layer
+                delta_out = [probs[c] - (1.0 if c == label else 0.0) for c in range(self.num_classes)]
+                # Update output weights and biases
                 for c in range(self.num_classes):
-                    error = (1.0 if c == label else 0.0) - probs[c]
-                    for i, val in enumerate(vec):
-                        self.weights[c][i] += self.lr * error * val
-                    self.biases[c] += self.lr * error
+                    for j in range(self.hidden_dim):
+                        self.out_weights[c][j] -= self.lr * delta_out[c] * hidden[j]
+                    self.out_biases[c] -= self.lr * delta_out[c]
+                # Gradient for hidden layer
+                delta_hidden = [0.0 for _ in range(self.hidden_dim)]
+                for j in range(self.hidden_dim):
+                    dh = 0.0
+                    for c in range(self.num_classes):
+                        dh += self.out_weights[c][j] * delta_out[c]
+                    dh *= 1.0 - hidden[j] ** 2  # derivative of tanh
+                    delta_hidden[j] = dh
+                    for i in range(len(vec)):
+                        self.hidden_weights[j][i] -= self.lr * dh * vec[i]
+                    self.hidden_biases[j] -= self.lr * dh
 
 
 class PackagePredictor:
@@ -74,8 +108,10 @@ class PackagePredictor:
         self.vocab = vocab
         self.size_classes = size_classes
         self.type_classes = type_classes
-        self.size_model = SimpleClassifier(len(vocab.token_to_index), len(size_classes))
-        self.type_model = SimpleClassifier(len(vocab.token_to_index), len(type_classes))
+        input_dim = len(vocab.token_to_index)
+        hidden_dim = max(2, input_dim // 2)
+        self.size_model = SimpleNN(input_dim, hidden_dim, len(size_classes))
+        self.type_model = SimpleNN(input_dim, hidden_dim, len(type_classes))
 
     def train(
         self,
@@ -106,10 +142,14 @@ class PackagePredictor:
             "vocab": self.vocab.token_to_index,
             "size_classes": self.size_classes,
             "type_classes": self.type_classes,
-            "size_weights": self.size_model.weights,
-            "size_biases": self.size_model.biases,
-            "type_weights": self.type_model.weights,
-            "type_biases": self.type_model.biases,
+            "size_hidden_weights": self.size_model.hidden_weights,
+            "size_hidden_biases": self.size_model.hidden_biases,
+            "size_out_weights": self.size_model.out_weights,
+            "size_out_biases": self.size_model.out_biases,
+            "type_hidden_weights": self.type_model.hidden_weights,
+            "type_hidden_biases": self.type_model.hidden_biases,
+            "type_out_weights": self.type_model.out_weights,
+            "type_out_biases": self.type_model.out_biases,
         }
         with open(path, "w") as f:
             json.dump(data, f)
@@ -121,8 +161,12 @@ class PackagePredictor:
         vocab = Vocabulary()
         vocab.token_to_index = data["vocab"]
         predictor = cls(vocab, data["size_classes"], data["type_classes"])
-        predictor.size_model.weights = data["size_weights"]
-        predictor.size_model.biases = data["size_biases"]
-        predictor.type_model.weights = data["type_weights"]
-        predictor.type_model.biases = data["type_biases"]
+        predictor.size_model.hidden_weights = data["size_hidden_weights"]
+        predictor.size_model.hidden_biases = data["size_hidden_biases"]
+        predictor.size_model.out_weights = data["size_out_weights"]
+        predictor.size_model.out_biases = data["size_out_biases"]
+        predictor.type_model.hidden_weights = data["type_hidden_weights"]
+        predictor.type_model.hidden_biases = data["type_hidden_biases"]
+        predictor.type_model.out_weights = data["type_out_weights"]
+        predictor.type_model.out_biases = data["type_out_biases"]
         return predictor

--- a/package_predictor/model.py
+++ b/package_predictor/model.py
@@ -6,24 +6,27 @@ import random
 from typing import List, Tuple, Dict
 
 
-def tokenize(name: str) -> List[str]:
-    """Split product name into words."""
-    return name.lower().split()
+def tokenize(text: str) -> List[str]:
+    """Split a piece of text into lowercase tokens."""
+    return text.lower().split()
 
 
 class Vocabulary:
     def __init__(self):
         self.token_to_index: Dict[str, int] = {}
 
-    def build(self, names: List[str]):
-        for name in names:
-            for token in tokenize(name):
+    def build(self, texts: List[str]):
+        """Build the vocabulary from a list of texts."""
+        for text in texts:
+            for token in tokenize(text):
                 if token not in self.token_to_index:
                     self.token_to_index[token] = len(self.token_to_index)
 
-    def vectorize(self, name: str) -> List[float]:
+    def vectorize(self, name: str, description: str) -> List[float]:
+        """Convert a name/description pair into a vector."""
+        text = f"{name} {description}"
         vec = [0.0] * len(self.token_to_index)
-        for token in tokenize(name):
+        for token in tokenize(text):
             idx = self.token_to_index.get(token)
             if idx is not None:
                 vec[idx] += 1.0
@@ -74,15 +77,21 @@ class PackagePredictor:
         self.size_model = SimpleClassifier(len(vocab.token_to_index), len(size_classes))
         self.type_model = SimpleClassifier(len(vocab.token_to_index), len(type_classes))
 
-    def train(self, names: List[str], size_labels: List[str], type_labels: List[str]):
-        X = [self.vocab.vectorize(name) for name in names]
+    def train(
+        self,
+        names: List[str],
+        descriptions: List[str],
+        size_labels: List[str],
+        type_labels: List[str],
+    ):
+        X = [self.vocab.vectorize(n, d) for n, d in zip(names, descriptions)]
         y_size = [self.size_classes.index(lbl) for lbl in size_labels]
         y_type = [self.type_classes.index(lbl) for lbl in type_labels]
         self.size_model.train(X, y_size)
         self.type_model.train(X, y_type)
 
-    def predict(self, name: str) -> Tuple[Tuple[str, float], Tuple[str, float]]:
-        vec = self.vocab.vectorize(name)
+    def predict(self, name: str, description: str) -> Tuple[Tuple[str, float], Tuple[str, float]]:
+        vec = self.vocab.vectorize(name, description)
         size_probs = self.size_model.predict_proba(vec)
         type_probs = self.type_model.predict_proba(vec)
         size_idx = max(range(len(size_probs)), key=lambda i: size_probs[i])

--- a/package_predictor/model.py
+++ b/package_predictor/model.py
@@ -1,0 +1,119 @@
+"""Simple neural network for package size and type prediction."""
+
+import json
+import math
+import random
+from typing import List, Tuple, Dict
+
+
+def tokenize(name: str) -> List[str]:
+    """Split product name into words."""
+    return name.lower().split()
+
+
+class Vocabulary:
+    def __init__(self):
+        self.token_to_index: Dict[str, int] = {}
+
+    def build(self, names: List[str]):
+        for name in names:
+            for token in tokenize(name):
+                if token not in self.token_to_index:
+                    self.token_to_index[token] = len(self.token_to_index)
+
+    def vectorize(self, name: str) -> List[float]:
+        vec = [0.0] * len(self.token_to_index)
+        for token in tokenize(name):
+            idx = self.token_to_index.get(token)
+            if idx is not None:
+                vec[idx] += 1.0
+        return vec
+
+
+def softmax(logits: List[float]) -> List[float]:
+    exps = [math.exp(x) for x in logits]
+    s = sum(exps)
+    return [e / s for e in exps]
+
+
+class SimpleClassifier:
+    def __init__(self, input_dim: int, num_classes: int, lr: float = 0.1):
+        self.lr = lr
+        self.num_classes = num_classes
+        self.weights = [
+            [random.uniform(-0.01, 0.01) for _ in range(input_dim)]
+            for _ in range(num_classes)
+        ]
+        self.biases = [0.0 for _ in range(num_classes)]
+
+    def predict_proba(self, vec: List[float]) -> List[float]:
+        logits = []
+        for c in range(self.num_classes):
+            logit = self.biases[c]
+            for i, val in enumerate(vec):
+                logit += self.weights[c][i] * val
+            logits.append(logit)
+        return softmax(logits)
+
+    def train(self, X: List[List[float]], y: List[int], epochs: int = 50):
+        for _ in range(epochs):
+            for vec, label in zip(X, y):
+                probs = self.predict_proba(vec)
+                for c in range(self.num_classes):
+                    error = (1.0 if c == label else 0.0) - probs[c]
+                    for i, val in enumerate(vec):
+                        self.weights[c][i] += self.lr * error * val
+                    self.biases[c] += self.lr * error
+
+
+class PackagePredictor:
+    def __init__(self, vocab: Vocabulary, size_classes: List[str], type_classes: List[str]):
+        self.vocab = vocab
+        self.size_classes = size_classes
+        self.type_classes = type_classes
+        self.size_model = SimpleClassifier(len(vocab.token_to_index), len(size_classes))
+        self.type_model = SimpleClassifier(len(vocab.token_to_index), len(type_classes))
+
+    def train(self, names: List[str], size_labels: List[str], type_labels: List[str]):
+        X = [self.vocab.vectorize(name) for name in names]
+        y_size = [self.size_classes.index(lbl) for lbl in size_labels]
+        y_type = [self.type_classes.index(lbl) for lbl in type_labels]
+        self.size_model.train(X, y_size)
+        self.type_model.train(X, y_type)
+
+    def predict(self, name: str) -> Tuple[Tuple[str, float], Tuple[str, float]]:
+        vec = self.vocab.vectorize(name)
+        size_probs = self.size_model.predict_proba(vec)
+        type_probs = self.type_model.predict_proba(vec)
+        size_idx = max(range(len(size_probs)), key=lambda i: size_probs[i])
+        type_idx = max(range(len(type_probs)), key=lambda i: type_probs[i])
+        return (
+            (self.size_classes[size_idx], size_probs[size_idx]),
+            (self.type_classes[type_idx], type_probs[type_idx]),
+        )
+
+    def save(self, path: str):
+        data = {
+            "vocab": self.vocab.token_to_index,
+            "size_classes": self.size_classes,
+            "type_classes": self.type_classes,
+            "size_weights": self.size_model.weights,
+            "size_biases": self.size_model.biases,
+            "type_weights": self.type_model.weights,
+            "type_biases": self.type_model.biases,
+        }
+        with open(path, "w") as f:
+            json.dump(data, f)
+
+    @classmethod
+    def load(cls, path: str) -> "PackagePredictor":
+        with open(path, "r") as f:
+            data = json.load(f)
+        vocab = Vocabulary()
+        vocab.token_to_index = data["vocab"]
+        predictor = cls(vocab, data["size_classes"], data["type_classes"])
+        predictor.size_model.weights = data["size_weights"]
+        predictor.size_model.biases = data["size_biases"]
+        predictor.type_model.weights = data["type_weights"]
+        predictor.type_model.biases = data["type_biases"]
+        return predictor

--- a/package_predictor/predict.py
+++ b/package_predictor/predict.py
@@ -1,0 +1,17 @@
+import sys
+from model import PackagePredictor
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python predict.py <product name>")
+        return
+    name = " ".join(sys.argv[1:])
+    predictor = PackagePredictor.load("model.json")
+    (size_label, size_conf), (type_label, type_conf) = predictor.predict(name)
+    print(f"Package size: {size_label} (confidence {size_conf:.2f})")
+    print(f"Package type: {type_label} (confidence {type_conf:.2f})")
+
+
+if __name__ == "__main__":
+    main()

--- a/package_predictor/predict.py
+++ b/package_predictor/predict.py
@@ -3,12 +3,13 @@ from model import PackagePredictor
 
 
 def main():
-    if len(sys.argv) < 2:
-        print("Usage: python predict.py <product name>")
+    if len(sys.argv) < 3:
+        print("Usage: python predict.py <product name> <description>")
         return
-    name = " ".join(sys.argv[1:])
+    name = sys.argv[1]
+    description = " ".join(sys.argv[2:])
     predictor = PackagePredictor.load("model.json")
-    (size_label, size_conf), (type_label, type_conf) = predictor.predict(name)
+    (size_label, size_conf), (type_label, type_conf) = predictor.predict(name, description)
     print(f"Package size: {size_label} (confidence {size_conf:.2f})")
     print(f"Package type: {type_label} (confidence {type_conf:.2f})")
 

--- a/package_predictor/train.py
+++ b/package_predictor/train.py
@@ -1,4 +1,5 @@
 import csv
+import hashlib
 from pathlib import Path
 from typing import List, Tuple
 
@@ -22,22 +23,15 @@ def main():
     names = [row[0] for row in data]
     descriptions = [row[1] for row in data]
 
-    # Since the CSV does not contain size/type labels, simulate them here
-    label_map = {
-        "cola": ("500ml", "bottle"),
-        "orange juice": ("1l", "bottle"),
-        "mineral water": ("500ml", "bottle"),
-        "potato chips": ("200g", "bag"),
-        "chocolate cookies": ("300g", "bag"),
-        "rice 5kg": ("5kg", "bag"),
-        "smartphone": ("small", "box"),
-        "laptop computer": ("medium", "box"),
-        "television": ("large", "box"),
-        "breakfast cereal": ("500g", "box"),
-    }
-
-    sizes = [label_map[name][0] for name in names]
-    types = [label_map[name][1] for name in names]
+    # Since the CSV does not contain size/type labels, generate synthetic ones
+    size_options = ["small", "medium", "large"]
+    type_options = ["bag", "box", "bottle"]
+    sizes = []
+    types = []
+    for name in names:
+        digest = hashlib.md5(name.encode("utf-8")).digest()
+        sizes.append(size_options[digest[0] % len(size_options)])
+        types.append(type_options[digest[1] % len(type_options)])
 
     vocab = Vocabulary()
     vocab.build(names + descriptions)

--- a/package_predictor/train.py
+++ b/package_predictor/train.py
@@ -10,7 +10,9 @@ def load_data(csv_path: str):
     with open(csv_path, newline="", encoding="utf-8") as f:
         reader = csv.DictReader(f)
         for row in reader:
-            records.append((row["name"], row["size"], row["type"]))
+            records.append(
+                (row["name"], row["description"], row["size"], row["type"])
+            )
     return records
 
 
@@ -19,16 +21,17 @@ def main():
     data = load_data(Path(__file__).with_name("data.csv"))
 
     names = [row[0] for row in data]
-    sizes = [row[1] for row in data]
-    types = [row[2] for row in data]
+    descriptions = [row[1] for row in data]
+    sizes = [row[2] for row in data]
+    types = [row[3] for row in data]
 
     vocab = Vocabulary()
-    vocab.build(names)
+    vocab.build(names + descriptions)
 
     size_classes = sorted(set(sizes))
     type_classes = sorted(set(types))
     predictor = PackagePredictor(vocab, size_classes, type_classes)
-    predictor.train(names, sizes, types)
+    predictor.train(names, descriptions, sizes, types)
     predictor.save("model.json")
     print("Model saved to model.json")
 

--- a/package_predictor/train.py
+++ b/package_predictor/train.py
@@ -1,0 +1,34 @@
+from model import Vocabulary, PackagePredictor
+
+
+def main():
+    data = [
+        ("cola", "500ml", "bottle"),
+        ("orange juice", "1l", "bottle"),
+        ("mineral water", "500ml", "bottle"),
+        ("potato chips", "200g", "bag"),
+        ("chocolate cookies", "300g", "bag"),
+        ("rice 5kg", "5kg", "bag"),
+        ("smartphone", "small", "box"),
+        ("laptop computer", "medium", "box"),
+        ("television", "large", "box"),
+        ("breakfast cereal", "500g", "box"),
+    ]
+
+    names = [row[0] for row in data]
+    sizes = [row[1] for row in data]
+    types = [row[2] for row in data]
+
+    vocab = Vocabulary()
+    vocab.build(names)
+
+    size_classes = sorted(set(sizes))
+    type_classes = sorted(set(types))
+    predictor = PackagePredictor(vocab, size_classes, type_classes)
+    predictor.train(names, sizes, types)
+    predictor.save("model.json")
+    print("Model saved to model.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/package_predictor/train.py
+++ b/package_predictor/train.py
@@ -1,18 +1,17 @@
 import csv
 from pathlib import Path
+from typing import List, Tuple
 
 from model import Vocabulary, PackagePredictor
 
 
-def load_data(csv_path: str):
-    """Load training data from a CSV file."""
+def load_data(csv_path: str) -> List[Tuple[str, str]]:
+    """Load name and description pairs from a CSV file."""
     records = []
     with open(csv_path, newline="", encoding="utf-8") as f:
         reader = csv.DictReader(f)
         for row in reader:
-            records.append(
-                (row["name"], row["description"], row["size"], row["type"])
-            )
+            records.append((row["name"], row["description"]))
     return records
 
 
@@ -22,8 +21,23 @@ def main():
 
     names = [row[0] for row in data]
     descriptions = [row[1] for row in data]
-    sizes = [row[2] for row in data]
-    types = [row[3] for row in data]
+
+    # Since the CSV does not contain size/type labels, simulate them here
+    label_map = {
+        "cola": ("500ml", "bottle"),
+        "orange juice": ("1l", "bottle"),
+        "mineral water": ("500ml", "bottle"),
+        "potato chips": ("200g", "bag"),
+        "chocolate cookies": ("300g", "bag"),
+        "rice 5kg": ("5kg", "bag"),
+        "smartphone": ("small", "box"),
+        "laptop computer": ("medium", "box"),
+        "television": ("large", "box"),
+        "breakfast cereal": ("500g", "box"),
+    }
+
+    sizes = [label_map[name][0] for name in names]
+    types = [label_map[name][1] for name in names]
 
     vocab = Vocabulary()
     vocab.build(names + descriptions)

--- a/package_predictor/train.py
+++ b/package_predictor/train.py
@@ -1,19 +1,22 @@
+import csv
+from pathlib import Path
+
 from model import Vocabulary, PackagePredictor
 
 
+def load_data(csv_path: str):
+    """Load training data from a CSV file."""
+    records = []
+    with open(csv_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            records.append((row["name"], row["size"], row["type"]))
+    return records
+
+
 def main():
-    data = [
-        ("cola", "500ml", "bottle"),
-        ("orange juice", "1l", "bottle"),
-        ("mineral water", "500ml", "bottle"),
-        ("potato chips", "200g", "bag"),
-        ("chocolate cookies", "300g", "bag"),
-        ("rice 5kg", "5kg", "bag"),
-        ("smartphone", "small", "box"),
-        ("laptop computer", "medium", "box"),
-        ("television", "large", "box"),
-        ("breakfast cereal", "500g", "box"),
-    ]
+    # Load data from a CSV file instead of hardcoding it
+    data = load_data(Path(__file__).with_name("data.csv"))
 
     names = [row[0] for row in data]
     sizes = [row[1] for row in data]


### PR DESCRIPTION
## Summary
- ignore cache files and saved models
- implement a small neural net from scratch to predict package size and type from a product name
- add training and prediction scripts
- document how to train and run predictions

## Testing
- `python train.py`
- `python predict.py "cola"`
- `python -m py_compile package_predictor/model.py package_predictor/train.py package_predictor/predict.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684257142d34832282c9962509472864